### PR TITLE
Fix non-default childrenField, TreeNodeContent not rendering, added dblclick and contextmenu events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,11 @@ npm-debug.log
 # IDE #
 .idea/
 *.swp
+
+angular2-tree-component.js
+angular2-tree-component.d.ts
+lib/**/*.js
+lib/components/*.d.ts
+lib/constants/*.d.ts
+lib/defs/api.d.ts
+lib/models/*.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,5 @@ node_modules
 example
 *webpack*conf*.js
 *karma*.js
+*.ts
+!*.d.ts

--- a/angular2-tree-component.ts
+++ b/angular2-tree-component.ts
@@ -1,0 +1,9 @@
+import { ITreeOptions } from './lib/models/tree-options.model';
+import { TreeModel } from './lib/models/tree.model';
+import { TreeComponent } from './lib/components/tree.component';
+
+export {
+  TreeModel,
+  ITreeOptions,
+  TreeComponent
+};

--- a/lib/angular2-tree.ts
+++ b/lib/angular2-tree.ts
@@ -1,9 +1,0 @@
-import { ITreeOptions } from './models/tree-options.model';
-import { TreeModel } from './models/tree.model';
-import { TreeComponent } from './components/tree.component';
-
-export {
-  TreeModel,
-  ITreeOptions,
-  TreeComponent
-};

--- a/lib/components/tree-node-content.component.ts
+++ b/lib/components/tree-node-content.component.ts
@@ -6,7 +6,6 @@ import { TreeModel } from '../models/tree.model';
   selector: 'TreeNodeContent',
   template: '',
 })
-
 export class TreeNodeContent implements AfterViewInit {
   @Input() node: TreeNode;
 

--- a/lib/components/tree-node-content.component.ts
+++ b/lib/components/tree-node-content.component.ts
@@ -1,31 +1,33 @@
-import { Component, Input, Output, EventEmitter, DynamicComponentLoader, QueryList, Query, ElementRef, AfterViewInit, ViewContainerRef } from '@angular/core';
+import { Component, Input, ComponentResolver, ComponentFactory, ComponentRef, AfterViewInit, ViewContainerRef } from '@angular/core';
 import { TreeNode } from '../models/tree-node.model';
 import { TreeModel } from '../models/tree.model';
-import { LoadingComponent } from './loading.component.ts';
 
 @Component({
   selector: 'TreeNodeContent',
-  template: ''
+  template: '',
 })
 
 export class TreeNodeContent implements AfterViewInit {
-  @Input() node:TreeNode;
+  @Input() node: TreeNode;
 
   constructor(
     private treeModel: TreeModel,
-    private componentLoader: DynamicComponentLoader,
-    private viewContainerRef: ViewContainerRef) {
+    private componentResolver: ComponentResolver,
+    private viewContainerRef: ViewContainerRef
+    ) {
   }
 
   ngAfterViewInit() {
-    setTimeout(() => this._loadTreeNodeContent());
+    this._loadTreeNodeContent();
   }
 
   _loadTreeNodeContent() {
-    this.componentLoader.loadNextToLocation(this.treeModel.treeNodeContentComponent,
-                                            this.viewContainerRef)
-      .then((componentRef) => {
+    this.componentResolver.resolveComponent(this.treeModel.treeNodeContentComponent)
+      .then((componentFactory: ComponentFactory<{ node: TreeNode }>) => {
+        let componentRef: ComponentRef<{ node: TreeNode }>
+          = this.viewContainerRef.createComponent(componentFactory, 0, this.viewContainerRef.injector);
         componentRef.instance.node = this.node;
+        componentRef.changeDetectorRef.detectChanges();
       });
   }
 }

--- a/lib/components/tree-node.component.ts
+++ b/lib/components/tree-node.component.ts
@@ -74,7 +74,6 @@ import { TreeNodeContent } from './tree-node-content.component';
     </div>
   `
 })
-
 export class TreeNodeComponent {
   @Input() node:TreeNode;
 

--- a/lib/components/tree-node.component.ts
+++ b/lib/components/tree-node.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, DynamicComponentLoader, QueryList, Query, ElementRef, AfterViewInit } from '@angular/core';
+import { Component, Input, Output, EventEmitter, DynamicComponentLoader, QueryList, Query, ElementRef, AfterViewInit, ChangeDetectorRef } from '@angular/core';
 import { TreeNode } from '../models/tree-node.model';
 import { LoadingComponent } from './loading.component';
 import { TreeNodeContent } from './tree-node-content.component';
@@ -30,7 +30,7 @@ import { TreeNodeContent } from './tree-node-content.component';
         display: inline-block;
         position: relative;
         background-repeat: no-repeat;
-        background-position: center;        
+        background-position: center;
     }`,
     `.toggle-children-placeholder {
         display: inline-block;
@@ -57,13 +57,12 @@ import { TreeNodeContent } from './tree-node-content.component';
         class="toggle-children-placeholder">
       </span>
       <div class="node-content-wrapper" (click)="node.toggleActivated()">
-        {{node.data.name}}
         <TreeNodeContent [node]="node"></TreeNodeContent>
       </div>
       <div class="tree-children" *ngIf="node.isExpanded">
         <div *ngIf="node.children">
-          <TreeNode          
-            *ngFor="#node of node.children"
+          <TreeNode
+            *ngFor="let node of node.children"
             [node]="node">
           </TreeNode>
         </div>

--- a/lib/components/tree-node.component.ts
+++ b/lib/components/tree-node.component.ts
@@ -50,13 +50,13 @@ import { TreeNodeContent } from './tree-node-content.component';
       <span
         *ngIf="node.hasChildren"
         class="toggle-children"
-        (click)="node.toggle()">
+        (click)="node.toggle($event)">
       </span>
       <span
         *ngIf="!node.hasChildren"
         class="toggle-children-placeholder">
       </span>
-      <div class="node-content-wrapper" (click)="node.toggleActivated()">
+      <div class="node-content-wrapper" (click)="node.toggleActivated($event)" (dblclick)="node.doubleClick($event)" (contextmenu)="node.contextMenu($event)">
         <TreeNodeContent [node]="node"></TreeNodeContent>
       </div>
       <div class="tree-children" *ngIf="node.isExpanded">

--- a/lib/components/tree.component.ts
+++ b/lib/components/tree.component.ts
@@ -58,6 +58,8 @@ export class TreeComponent implements OnChanges {
   @Output() onDeactivate;
   @Output() onFocus;
   @Output() onBlur;
+  @Output() onDoubleClick;
+  @Output() onContextMenu;
 
   onKeydown($event) {
     let focusedNode = this.treeModel.focusedNode;

--- a/lib/components/tree.component.ts
+++ b/lib/components/tree.component.ts
@@ -38,7 +38,6 @@ const _ = require('lodash');
     </div>
   `
 })
-
 export class TreeComponent implements OnChanges {
   constructor(public treeModel:TreeModel) {
     treeModel.eventNames.forEach((name) => this[name] = new EventEmitter());

--- a/lib/components/tree.component.ts
+++ b/lib/components/tree.component.ts
@@ -60,6 +60,7 @@ export class TreeComponent implements OnChanges {
   @Output() onBlur;
   @Output() onDoubleClick;
   @Output() onContextMenu;
+  @Output() onInitialized;
 
   onKeydown($event) {
     let focusedNode = this.treeModel.focusedNode;

--- a/lib/components/tree.component.ts
+++ b/lib/components/tree.component.ts
@@ -32,7 +32,7 @@ const _ = require('lodash');
     <div class="tree">
       <TreeNode
         (click)="treeModel.setFocus(true)"
-        *ngFor="#node of treeModel.roots"
+        *ngFor="let node of treeModel.roots"
         [node]="node">
       </TreeNode>
     </div>

--- a/lib/constants/events.ts
+++ b/lib/constants/events.ts
@@ -4,5 +4,7 @@ export const TREE_EVENTS = {
   onActivate: 'onActivate',
   onDeactivate: 'onDeactivate',
   onFocus: 'onFocus',
-  onBlur: 'onBlur'
+  onBlur: 'onBlur',
+  onDoubleClick: 'onDoubleClick',
+  onContextMenu: 'onContextMenu',
 }

--- a/lib/constants/events.ts
+++ b/lib/constants/events.ts
@@ -7,4 +7,5 @@ export const TREE_EVENTS = {
   onBlur: 'onBlur',
   onDoubleClick: 'onDoubleClick',
   onContextMenu: 'onContextMenu',
+  onInitialized: 'onInitialized',
 }

--- a/lib/models/tree-node.model.ts
+++ b/lib/models/tree-node.model.ts
@@ -1,7 +1,7 @@
 import { ElementRef } from '@angular/core';
 import { TreeModel } from './tree.model';
 import { ITreeNode } from '../defs/api';
-import { TREE_EVENTS } from '../constants/events'; 
+import { TREE_EVENTS } from '../constants/events';
 
 const _ = require('lodash');
 
@@ -33,7 +33,7 @@ export class TreeNode implements ITreeNode {
     this.hasChildren = !!(data.hasChildren || data[this.options.childrenField]);
     if (data[this.options.childrenField]) {
       this.children = data[this.options.childrenField]
-        .map(c => new TreeNode(c, this, treeModel));      
+        .map(c => new TreeNode(c, this, treeModel));
     }
   }
 

--- a/lib/models/tree-node.model.ts
+++ b/lib/models/tree-node.model.ts
@@ -30,7 +30,7 @@ export class TreeNode implements ITreeNode {
   constructor(public data:any, public parent:TreeNode = null, public treeModel:TreeModel) {
     this.level = this.parent ? this.parent.level + 1 : 0;
     this.path = this.parent ? [...this.parent.path, this.id] : [];
-    this.hasChildren = !!(data.hasChildren || data[this.options.childrenField]);
+    this.hasChildren = !!(data.hasChildren || (data[this.options.childrenField] && data[this.options.childrenField].length > 0));
     if (data[this.options.childrenField]) {
       this.children = data[this.options.childrenField]
         .map(c => new TreeNode(c, this, treeModel));
@@ -162,5 +162,16 @@ export class TreeNode implements ITreeNode {
     if (previousNode) {
       this.fireEvent({ eventName: TREE_EVENTS.onBlur, node: this });
     }
+  }
+
+  doubleClick(rawEvent: MouseEvent) {
+    this.fireEvent({ eventName: TREE_EVENTS.onDoubleClick, node: this, rawEvent: rawEvent });
+  }
+
+  contextMenu(rawEvent: MouseEvent) {
+    if (this.options.hasCustomContextMenu) {
+      rawEvent.preventDefault();
+    }
+    this.fireEvent({ eventName: TREE_EVENTS.onContextMenu, node: this, rawEvent: rawEvent });
   }
 }

--- a/lib/models/tree-node.model.ts
+++ b/lib/models/tree-node.model.ts
@@ -1,5 +1,6 @@
 import { ElementRef } from '@angular/core';
 import { TreeModel } from './tree.model';
+import { TreeOptions } from './tree-options.model';
 import { ITreeNode } from '../defs/api';
 import { TREE_EVENTS } from '../constants/events';
 
@@ -44,7 +45,7 @@ export class TreeNode implements ITreeNode {
   get realParent() { return this.isRoot ? null : this.parent }
 
   // proxy to treeModel:
-  get options() { return this.treeModel.options }
+  get options(): TreeOptions { return this.treeModel.options }
   fireEvent(event) { this.treeModel.fireEvent(event) }
 
   // field accessors:

--- a/lib/models/tree-options.model.ts
+++ b/lib/models/tree-options.model.ts
@@ -9,6 +9,7 @@ export interface ITreeOptions {
   treeNodeTemplate: any;
   loadingComponent: any;
   getChildren(node:TreeNode): any;
+  hasCustomContextMenu: boolean;
 }
 
 export class TreeOptions {
@@ -18,6 +19,7 @@ export class TreeOptions {
   treeNodeTemplate: any = '{{ node.displayField }}';
   loadingComponent: any = 'loading...';
   getChildren = null;
+  hasCustomContextMenu = false;
 
   constructor(options = {}) {
     _.extend(this, options);

--- a/lib/models/tree-options.model.ts
+++ b/lib/models/tree-options.model.ts
@@ -15,7 +15,7 @@ export class TreeOptions {
   childrenField:string = 'children';
   displayField:string = 'name';
   idField:string = 'id';
-  treeNodeTemplate: any = '{{ node.displayField }}';
+  treeNodeTemplate: any = '';
   loadingComponent: any = 'loading...';
   getChildren = null;
 

--- a/lib/models/tree-options.model.ts
+++ b/lib/models/tree-options.model.ts
@@ -15,7 +15,7 @@ export class TreeOptions {
   childrenField:string = 'children';
   displayField:string = 'name';
   idField:string = 'id';
-  treeNodeTemplate: any = '';
+  treeNodeTemplate: any = '{{ node.displayField }}';
   loadingComponent: any = 'loading...';
   getChildren = null;
 

--- a/lib/models/tree.model.ts
+++ b/lib/models/tree.model.ts
@@ -78,7 +78,7 @@ export class TreeModel implements ITreeModel {
     }
   }
 
-  _createAdHocComponent(templateStr) {
+  _createAdHocComponent(templateStr): any {
     @Component({
         selector: 'TreeNodeTemplate',
         template: templateStr

--- a/lib/models/tree.model.ts
+++ b/lib/models/tree.model.ts
@@ -18,9 +18,13 @@ export class TreeModel implements ITreeModel {
   eventNames = Object.keys(TREE_EVENTS);
 
   setData({ nodes, options, events }) {
-    this.options = new TreeOptions(options);
+    if (options) {
+      this.options = new TreeOptions(options);
+    }
 
-    const virtualRoot = new TreeNode({ virtual: true, children: nodes }, null, this);
+    let treeNodeConfig = { virtual: true };
+    treeNodeConfig[this.options.childrenField] = nodes;
+    const virtualRoot = new TreeNode(treeNodeConfig, null, this);
 
     this.roots = virtualRoot.children;
 

--- a/lib/models/tree.model.ts
+++ b/lib/models/tree.model.ts
@@ -31,6 +31,7 @@ export class TreeModel implements ITreeModel {
     this._initTreeNodeContentComponent();
     this._initLoadingComponent();
     this.events = events;
+    this.fireEvent({ eventName: TREE_EVENTS.onInitialized });
   }
 
   fireEvent(event) {

--- a/package.json
+++ b/package.json
@@ -5,31 +5,41 @@
   "author": "Adam Klein <adam@500tech.com>",
   "homepage": "https://github.com/500tech/angular2-tree-component",
   "license": "MIT",
-  "main": "lib/angular2-tree",
-  "typings": "lib/defs/angular2-tree.d.ts",
+  "main": "angular2-tree-component",
+  "typings": "angular2-tree-component.d.ts",
   "keywords": ["angular2", "tree", "angular2-tree", "ng2", "ng2-tree"],
   "scripts": {
-    "test": "karma start"
+    "test": "karma start",
+    "clean": "rimraf node_modules && npm run clean:typescript && npm cache clean",
+    "clean:typescript": "rimraf angular2-tree.js angular2-tree.d.ts ./lib/**/*.js ./lib/components/*.d.ts ./lib/constants/*.d.ts ./lib/defs/api.d.ts ./lib/models/*.d.ts",
+    "build": "tsc",
+    "postinstall": "typings install"
   },
   "contributors": [
     "Adam Klein <adam@500tech.com>"
   ],
-  "peerDependencies": {
-    "@angular/common":  "2.0.0-rc.1",
-    "@angular/compiler":  "2.0.0-rc.1",
-    "@angular/core":  "2.0.0-rc.1",
-    "@angular/http":  "2.0.0-rc.1",
-    "@angular/platform-browser":  "2.0.0-rc.1",
-    "@angular/platform-browser-dynamic":  "2.0.0-rc.1",
-    "@angular/router":  "2.0.0-rc.1",
-    "@angular/router-deprecated":  "2.0.0-rc.1",
+  "dependencies": {
+    "@angular/common": "2.0.0-rc.1",
+    "@angular/compiler": "2.0.0-rc.1",
+    "@angular/core": "2.0.0-rc.1",
+    "@angular/http": "2.0.0-rc.1",
+    "@angular/platform-browser": "2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.1",
+    "@angular/router": "2.0.0-rc.1",
+    "@angular/router-deprecated": "2.0.0-rc.1",
     "@angular/upgrade":  "2.0.0-rc.1",
+    "es6-promise": "^3.1.2",
+    "es6-shim": "^0.35.0",
+    "lodash": "4.6.1",
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.0-beta.6",
     "zone.js": "^0.6.12"
   },
-  "dependencies": {
-    "lodash": "4.6.1"
+  "devDependencies": {
+    "rimraf": "^2.5.1",
+    "typedoc": "^0.3.12",
+    "typescript": "^1.8.0",
+    "typings": "^0.8.1"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES5",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "declaration": true
+  },
+  "exclude": [
+    "example",
+    "node_modules",
+    "typings/main",
+    "typings/main.d.ts"
+  ],
+  "compileOnSave": false,
+  "buildOnSave": false
+}

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,9 @@
+{
+  "ambientDevDependencies": {
+    "jasmine": "registry:dt/jasmine#2.2.0+20160412134438"
+  },
+  "ambientDependencies": {
+    "es6-shim": "registry:dt/es6-shim#0.31.2+20160317120654",
+    "node": "registry:dt/node#4.0.0+20160501135006"
+  }
+}


### PR DESCRIPTION
I made three changes:

1. Updated the setData function to account for a non-default childrenField
2. Changed the way TreeNodeContent is being loaded.
    - I'm using ComponentResolver instead of DynamicComponentLoader, since evidently DynamicComponentLoader is being deprecated.  (http://stackoverflow.com/a/35508835/5191105)
    - I removed the setTimeout before loading TreeNodeContent and instead use componentRef.changeDetectorRef.detectChanges() once it is instantiated.

3. Changed `#node of ...` to `let node of ...` since they like to change the syntax every couple weeks.