### PR TITLE
Set ViewEncapsulation to None to allow override of styles

### DIFF
--- a/lib/components/tree-node.component.ts
+++ b/lib/components/tree-node.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, DynamicComponentLoader, QueryList, Query, ElementRef, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, Output, EventEmitter, DynamicComponentLoader, QueryList, Query, ElementRef, AfterViewInit, ChangeDetectorRef, ViewEncapsulation } from '@angular/core';
 import { TreeNode } from '../models/tree-node.model';
 import { LoadingComponent } from './loading.component';
 import { TreeNodeContent } from './tree-node-content.component';
@@ -6,6 +6,7 @@ import { TreeNodeContent } from './tree-node-content.component';
 @Component({
   selector: 'TreeNode',
   directives: [TreeNodeComponent, LoadingComponent, TreeNodeContent],
+  encapsulation: ViewEncapsulation.None,
   styles: [
     '.tree-children { padding-left: 20px }',
     `.node-content-wrapper {

--- a/lib/components/tree.component.ts
+++ b/lib/components/tree.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, OnChanges, SimpleChange, EventEmitter } from '@angular/core';
+import { Component, Input, Output, OnChanges, SimpleChange, EventEmitter, ViewEncapsulation } from '@angular/core';
 import { TreeNodeComponent } from './tree-node.component';
 import { TreeModel } from '../models/tree.model';
 import { TreeNode } from '../models/tree-node.model';
@@ -10,6 +10,7 @@ import * as _ from 'lodash'
 @Component({
   selector: 'Tree',
   directives: [TreeNodeComponent],
+  encapsulation: ViewEncapsulation.None,
   host: {
     '(body: keydown)': "onKeydown($event)",
     '(body: mousedown)': "onMousedown($event)"


### PR DESCRIPTION
Setting ViewEncapsulation to None so the styles can be overwritten as proposed in the README