### PR TITLE
Fix isExpanded typo

### DIFF
--- a/lib/models/tree-node.model.ts
+++ b/lib/models/tree-node.model.ts
@@ -32,7 +32,7 @@ export class TreeNode implements ITreeNode {
     this.level = this.parent ? this.parent.level + 1 : 0;
     this.path = this.parent ? [...this.parent.path, this.id] : [];
     
-    if (this.getField('expanded')) this.isExpanded = true;
+    if (this.getField('isExpanded')) this.isExpanded = true;
     if (this.getField('children')) {
       this.children = this.getField('children')
         .map(c => new TreeNode(c, this, treeModel));


### PR DESCRIPTION
There is an issue with the **isExpanded** field of the initial model. Currently the tree component just ignores it. I found the problem - a typo in a config field name. Now it should work fine.