### PR TITLE
Changed postinstall script to prebuild in package.json ("typings install")

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "tsc",
     "example:webpack": "npm run build && cp -rf dist example/webpack/node_modules/angular2-tree-component/ && cd example/webpack && npm start",
     "example:systemjs": "npm run build && cp -rf dist example/systemjs/node_modules/angular2-tree-component/ && cd example/systemjs && npm start",
-    "example:webpack:build": "cd example/webpack && npm run build"
+    "example:webpack:build": "cd example/webpack && npm run build",
     "prebuild": "typings install"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "example:webpack": "npm run build && cp -rf dist example/webpack/node_modules/angular2-tree-component/ && cd example/webpack && npm start",
     "example:systemjs": "npm run build && cp -rf dist example/systemjs/node_modules/angular2-tree-component/ && cd example/systemjs && npm start",
     "example:webpack:build": "cd example/webpack && npm run build"
+    "prebuild": "typings install"
   },
   "files": [
     "dist/"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "build": "tsc",
     "example:webpack": "npm run build && cp -rf dist example/webpack/node_modules/angular2-tree-component/ && cd example/webpack && npm start",
     "example:systemjs": "npm run build && cp -rf dist example/systemjs/node_modules/angular2-tree-component/ && cd example/systemjs && npm start",
-    "example:webpack:build": "cd example/webpack && npm run build",
-    "postinstall": "typings install"
+    "example:webpack:build": "cd example/webpack && npm run build"
   },
   "files": [
     "dist/"


### PR DESCRIPTION
npm installing angular2-tree-component resulted in an error due to failing postinstall script. 
This PR fixes it.