### PR TITLE
Move typings into dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "lodash": "^4.6.1",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^5.0.0-beta.12",
-    "ts-helpers": "^1.1.1",
-    "typings": "^0.8.1"
+    "ts-helpers": "^1.1.1"
   },
   "devDependencies": {
     "zone.js": "^0.6.21",
@@ -60,7 +59,8 @@
     "@angular/platform-browser-dynamic": "^2.0.0",
     "rimraf": "^2.5.1",
     "typedoc": "^0.3.12",
-    "typescript": "^1.8.0"
+    "typescript": "^1.8.0",
+    "typings": "^0.8.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Having `typings` as a regular dependency, rather than a dev dependency, means that other projects keep failing when using post 1.x version of typings.

This change moves typings from `dependencies` to `devDependecies`.

