### PR TITLE
Enable drag/drop across trees.

### DIFF
--- a/lib/defs/api.ts
+++ b/lib/defs/api.ts
@@ -36,9 +36,14 @@ export interface ITreeOptions {
     */
    actionMapping?: any;
    /**
-    * Allow drag and drop on the tree. Default: false
+    * Allow drag from this tree. Default: false
     */
    allowDrag?: boolean;
+  /**
+   * Allow drop on this tree. Default: null
+   * (interpreted as "true" if allowDrag==true and allowDrop==null for backwards compatibility)
+   */
+   allowDrop?: boolean;
    /**
     * deprecated
     */


### PR DESCRIPTION
Changes to allow drag from one tree and drop on another.  Due to potential difference in tree models, internal movement/manipulation of nodes is disabled for intra-tree drops and must be implemented seperately.  To allow this, the onMoveNode event now receives an additional "from" parameter allowing access to the source node (and therefore tree model, options, etc).