### PR TITLE
Update to Angular 2.3.0 and update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,21 +32,21 @@
     "Adam Klein <adam@500tech.com>"
   ],
   "peerDependencies": {
-    "@angular/core": "^2.0.0",
-    "@angular/common": "^2.0.0"
+    "@angular/core": "^2.3.0",
+    "@angular/common": "^2.3.0"
   },
   "dependencies": {
     "lodash": "^4.6.1"
   },
   "devDependencies": {
-    "@angular/common": "^2.0.0",
-    "@angular/compiler": "^2.0.0",
-    "@angular/compiler-cli": "^2.0.0",
-    "@angular/core": "^2.0.0",
-    "@angular/http": "^2.0.0",
-    "@angular/platform-browser": "^2.0.0",
-    "@angular/platform-browser-dynamic": "^2.0.0",
-    "@angular/platform-server": "^2.0.1",
+    "@angular/common": "^2.3.0",
+    "@angular/compiler": "^2.3.0",
+    "@angular/compiler-cli": "^2.3.0",
+    "@angular/core": "^2.3.0",
+    "@angular/http": "^2.3.0",
+    "@angular/platform-browser": "^2.3.0",
+    "@angular/platform-browser-dynamic": "^2.3.0",
+    "@angular/platform-server": "^2.3.0",
     "@types/core-js": "0.9.34",
     "@types/jasmine": "2.5.38",
     "@types/lodash": "4.14.40",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   "peerDependencies": {
     "@angular/core": "^2.0.0",
     "@angular/common": "^2.0.0",
+  },
+  "dependencies": {
     "lodash": "^4.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,22 +32,11 @@
     "Adam Klein <adam@500tech.com>"
   ],
   "peerDependencies": {
-    "@angular/common": "^2.0.0",
-    "@angular/compiler": "^2.0.0",
     "@angular/core": "^2.0.0",
-    "@angular/http": "^2.0.0",
-    "@angular/platform-browser": "^2.0.0",
-    "@angular/platform-browser-dynamic": "^2.0.0",
-    "zone.js": "^0.6.21"
+    "@angular/common": "^2.0.0"
   },
   "dependencies": {
-    "core-js": "^2.4.0",
-    "es6-promise": "^3.1.2",
-    "es6-shim": "^0.35.0",
-    "lodash": "^4.6.1",
-    "reflect-metadata": "^0.1.3",
-    "rxjs": "5.0.0-beta.12",
-    "ts-helpers": "^1.1.1"
+    "lodash": "^4.6.1"
   },
   "devDependencies": {
     "@angular/common": "^2.0.0",
@@ -58,17 +47,19 @@
     "@angular/platform-browser": "^2.0.0",
     "@angular/platform-browser-dynamic": "^2.0.0",
     "@angular/platform-server": "^2.0.1",
-    "@types/angular2": "0.0.2",
     "@types/core-js": "0.9.34",
     "@types/jasmine": "2.5.38",
     "@types/lodash": "4.14.40",
     "@types/node": "^6.0.38",
     "@types/rx": "2.5.34",
     "@types/webpack": "^1.12.29",
+    "core-js": "^2.4.0",
+    "reflect-metadata": "^0.1.3",
     "rimraf": "^2.5.1",
+    "rxjs": "5.0.0-rc.4",
     "typedoc": "^0.3.12",
-    "typescript": "^2.0.3",
-    "zone.js": "^0.6.21"
+    "typescript": "^2.1.4",
+    "zone.js": "^0.7.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,8 @@
     "Adam Klein <adam@500tech.com>"
   ],
   "peerDependencies": {
-    "@angular/core": "^2.3.0",
-    "@angular/common": "^2.3.0"
-  },
-  "dependencies": {
+    "@angular/core": "^2.0.0",
+    "@angular/common": "^2.0.0",
     "lodash": "^4.6.1"
   },
   "devDependencies": {
@@ -54,6 +52,7 @@
     "@types/rx": "2.5.34",
     "@types/webpack": "^1.12.29",
     "core-js": "^2.4.0",
+    "lodash": "^4.6.1",
     "reflect-metadata": "^0.1.3",
     "rimraf": "^2.5.1",
     "rxjs": "5.0.0-rc.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
   "compileOnSave": false,
   "buildOnSave": false,
   "angularCompilerOptions": {
-    "genDir": "compiled"
+    "genDir": "compiled",
+    "skipMetadataEmit": true
   }
 }


### PR DESCRIPTION
As a library, the `dependencies/peerDependencies` should be limited to exactly what is needed at runtime when using this library. Any other dependencies required for developing, building or running included examples should be added as `devDependencies`.

This PR cleans up the dependencies of the library, while also updating the Angular 2 peerDependencies to match version 2.3.0.