### PR TITLE
Fixed isActive

### DIFF
--- a/lib/models/tree.model.ts
+++ b/lib/models/tree.model.ts
@@ -257,7 +257,7 @@ export class TreeModel implements ITreeModel {
   }
 
   isActive(node) {
-    return this.activeNodeIds[node.id];
+    return this.activeNodeIds[node.id]?true:false;
   }
 
   setActiveNode(node, value, multi = false) {


### PR DESCRIPTION
isActive getter was either returning undefined or a value.
Therefore, the toggleActivated function was doing `setActive(!this.isActive).` 
So, when isActive was equal to undefined, `!this.isActive`was still undefined.