### PR TITLE
Use tsconfig instead of @types/core-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@angular/platform-browser": "^2.3.0",
     "@angular/platform-browser-dynamic": "^2.3.0",
     "@angular/platform-server": "^2.3.0",
-    "@types/core-js": "0.9.34",
     "@types/jasmine": "2.5.38",
     "@types/lodash": "4.14.40",
     "@types/node": "^6.0.38",
@@ -55,9 +54,8 @@
     "@types/webpack": "^1.12.29",
     "core-js": "^2.4.0",
     "lodash": "^4.6.1",
-    "reflect-metadata": "^0.1.3",
     "rimraf": "^2.5.1",
-    "rxjs": "5.0.0-rc.4",
+    "rxjs": "^5.0.0",
     "typedoc": "^0.3.12",
     "typescript": "^2.1.4",
     "zone.js": "^0.7.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,9 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es5",
+    "lib": [
+      "es2015", "dom"
+    ],
     "outDir": "dist/",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
By removing the `@types/core-js` dependency, and updating `tsconfig` to use the `lib` option, there is no longer a compile-time (or run-time) dependency on `core-js`, even though it will be used for any polyfills at run-time.

Additionally, since `core-js` contains all the necessary polyfills for Reflect Metadata, the `reflect-metadata` dependency can also be removed, please see angular/angular.io#1748.

Fixes #139 