### PR TITLE
fix the drag and drop Firefox issue

### DIFF
--- a/lib/directives/tree-drag.directive.ts
+++ b/lib/directives/tree-drag.directive.ts
@@ -17,7 +17,10 @@ export class TreeDragDirective implements DoCheck {
     this.renderer.setElementAttribute(this.el.nativeElement, 'draggable', this.treeDragEnabled ? "true" : "false");
   }
 
-  @HostListener('dragstart') onDragStart() {
+  @HostListener('dragstart', ['$event']) onDragStart(ev) {
+    // setting the data is required by firefox
+    ev.dataTransfer.setData("text/plain", ev.target.id);
+    
     setTimeout(() => this.treeDraggedElement.set(this.draggedElement), 30);
   }
 


### PR DESCRIPTION
fix #117 

http://stackoverflow.com/questions/19055264/why-doesnt-html5-drag-and-drop-work-in-firefox